### PR TITLE
Added akhq + ensure that brokers are started with required config for…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - 22181:2181
   
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.0.0
     depends_on:
       - zookeeper
     ports:
@@ -21,6 +21,9 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
 
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.15.0
@@ -29,3 +32,15 @@ services:
       - 9300:9300
     environment:
       discovery.type: single-node
+
+  akhq:
+    image: tchiotludo/akhq
+    environment:
+      AKHQ_CONFIGURATION: |
+        akhq:
+          connections:
+            docker-kafka-server:
+              properties:
+                bootstrap.servers: "cloudmc-monetization-local_kafka_1:9092"
+    ports:
+      - 3000:8080


### PR DESCRIPTION
## Issue

Local kafka runs a single broker kafka cluster. By default the internal transaction changelog topics are expecting at least 3 replicas which causes message producing to fail from cloudmc

### Solution

- specify a single replica for the internal change logs (we only have one broker)
- Use a set version (the latest version was preventing kafka from starting up)
- add akhq so we have some visibility 

I also set a fixed version. Using latest caused the startup of the broker to fail. 