### PR TITLE
Updated docker host for akhq which was wrong

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,6 @@ services:
           connections:
             docker-kafka-server:
               properties:
-                bootstrap.servers: "cloudmc-monetization-local_kafka_1:9092"
+                bootstrap.servers: "cloudmc-monetization-local-kafka-1:9092"
     ports:
       - 3000:8080


### PR DESCRIPTION
### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)

#### Code walkthrough : @INSERT_NAME
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
The AKHQ configuration was not pointing to the right host name causing it to not display

#### Solution
Fixed the AKHQ configuration

#### Test cases
- Manual test locally with monetization

#### UI changes
No changes

<!-- Uncomment if PRs from other repos related to the same story 
#### Related PRs
- PR #
-->
