### PR TITLE
Updated configuration to specify what to add for kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ cloudmc.elasticsearch.rest.read-timeout=30000
 
 # Usage records pushed to kafka topic
 cloudmc.kafka.bootstrap.server=localhost:29092
+cloudmc.kafka.security.protocol=PLAINTEXT
+cloudmc.kafka.topic.replicas=1
+
 ```
 
 ## Manually sending data to a topic


### PR DESCRIPTION
…kafka at startup

### Fixes [MC-19799](https://cloud-ops.atlassian.net/browse/MC-19799)

#### Code walkthrough : @lamminade 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
With Monetization local project, it is not possible to run CloudMC pointing to it since it requires 3 replicas for topics/templates.

#### Solution
Added the possibility to specify the number of replicas for topics in CloudMC configuration.

#### Test cases
- Unit test
- CloudMc Local test with monetization docker

#### UI changes
No changes

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-monetization-local/pull/4
- PR # https://github.com/cloudops/cloudmc-core/pull/2632