### PR TITLE
Added doc to explain how to fix AKHQ kafka dns name since some versio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To exit, press `Ctrl+C`
 More info [here](https://docs.confluent.io/platform/current/app-development/kafkacat-usage.html#consumer-mode)
 
 ## Connection problem in AKHQ
-Depending on you docker version, you may be experiencing some connectivity issue in AKHQ to Kafka.
+Depending on your version of docker, you may be experiencing some connectivity issues in AKHQ to Kafka.
 Please verify first that both Zookeeper and Kafka containers are up. If it is so, you need to do an update to the docker-compose.yaml file. 
 
 You must update the file from : 

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ docker-compose up -d
 ```
 
 
-It seems the docker container name generation changed in the most recent version of docker. They use now hyphens instead of underscores.
+It seems the docker container name generation changed in the most recent version of docker. They now use hyphens instead of underscores.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker compose file to setup local ES and Kafka environment.
 To install and run ES and Kafka:
 
 ```
-docker-compose up
+docker-compose up -d
 ```
 
 NB: if the containers exit with code 137, this means they are OOM. Add more memory
@@ -51,3 +51,38 @@ To manually read data from a topic, run this command:
 To exit, press `Ctrl+C`
 
 More info [here](https://docs.confluent.io/platform/current/app-development/kafkacat-usage.html#consumer-mode)
+
+## Connection problem in AKHQ
+Depending on you docker version, you may be experiencing some connectivity issue in AKHQ to Kafka.
+Please verify first that both Zookeeper and Kafka containers are up. If it is so, you need to do an update to the docker-compose.yaml file. 
+
+You must update the file from : 
+```
+  akhq:
+    environment:
+      AKHQ_CONFIGURATION: |
+        akhq:
+          connections:
+            docker-kafka-server:
+              properties:
+                bootstrap.servers: "cloudmc-monetization-local-kafka-1:9092"
+```
+to :
+```
+  akhq:
+    environment:
+      AKHQ_CONFIGURATION: |
+        akhq:
+          connections:
+            docker-kafka-server:
+              properties:
+                bootstrap.servers: "cloudmc-monetization-local_kafka_1:9092"
+```
+
+Then run again the docker-compose command.
+```
+docker-compose up -d
+```
+
+
+It seems the docker container name generation changed in the most recent version of docker. They use now hyphens instead of underscores.


### PR DESCRIPTION
…n of docker generates name differently

### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)

#### Code walkthrough : @INSERT_NAME
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
While doing the AR, we found that docker generates container name differently depending on the version.

#### Solution
Added an explanation on what to update to make it work.

